### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete multi-character sanitization

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "uuid": "^11.1.0",
     "yet-another-react-lightbox": "^3.23.2",
     "zod": "^3.25.7",
-    "zustand": "^5.0.4"
+    "zustand": "^5.0.4",
+    "sanitize-html": "^2.17.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/src/app/api/admin/email-templates/preview/route.ts
+++ b/src/app/api/admin/email-templates/preview/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import sanitizeHtml from 'sanitize-html';
 import { prisma } from '@/lib/db/prisma';
 import { verifyAdminAccess } from '@/lib/utils/server';
 import { sendEmail } from '@/lib/email/email';
@@ -115,7 +116,7 @@ export async function POST(request: NextRequest) {
       to: data.email,
       subject,
       html: processedContent,
-      text: processedContent.replace(/<[^>]*>/g, ''), // Strip HTML tags for text version
+      text: sanitizeHtml(processedContent, { allowedTags: [], allowedAttributes: {} }), // Strip all HTML tags for text version
     });
 
     return NextResponse.json({


### PR DESCRIPTION
Potential fix for [https://github.com/hudsor01/tattoo-website/security/code-scanning/4](https://github.com/hudsor01/tattoo-website/security/code-scanning/4)

To fix the issue, we need to ensure that all potentially dangerous content, including incomplete or malformed HTML tags, is removed from `processedContent`. A robust solution is to use a well-tested library like `sanitize-html` to sanitize the content. This library is specifically designed to handle edge cases and ensures that all unsafe HTML content is removed. Alternatively, we can repeatedly apply the regular expression replacement until no more matches are found, but using a library is the preferred approach for reliability and maintainability.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
