### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,8 @@
 name: "CodeQL"
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/hudsor01/tattoo-website/security/code-scanning/6](https://github.com/hudsor01/tattoo-website/security/code-scanning/6)

To fix the issue, we need to explicitly define the permissions for the workflow. Since the CodeQL workflow primarily involves analyzing code and does not require write permissions, we can set the permissions to `contents: read` at the workflow level. This ensures that the workflow has only the minimal permissions required to perform its tasks.

The changes will be made at the root level of the workflow file, adding a `permissions` block with `contents: read`. This will apply to all jobs in the workflow unless overridden by job-specific permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
