### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete multi-character sanitization

### DIFF
--- a/src/app/api/admin/email-campaigns/[id]/send/route.ts
+++ b/src/app/api/admin/email-campaigns/[id]/send/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import sanitizeHtml from 'sanitize-html';
 import { prisma } from '@/lib/db/prisma';
 import { verifyAdminAccess } from '@/lib/utils/server';
 import { sendEmail } from '@/lib/email/email';
@@ -141,7 +142,7 @@ export async function POST(request: NextRequest, { params }: { params: { id: str
             to: recipient.client.email,
             subject: campaign.subject,
             html: processedContent,
-            text: processedContent.replace(/<[^>]*>/g, ''), // Strip HTML for text version
+            text: sanitizeHtml(processedContent, { allowedTags: [], allowedAttributes: {} }), // Strip all HTML for text version
           });
 
           // Update recipient status


### PR DESCRIPTION
Potential fix for [https://github.com/hudsor01/tattoo-website/security/code-scanning/3](https://github.com/hudsor01/tattoo-website/security/code-scanning/3)

To fix the issue, we should replace the custom regex-based sanitization with a well-tested library like `sanitize-html`. This library is specifically designed to handle HTML sanitization and ensures that all unsafe tags and attributes, including `<script>` tags, are removed. This approach is more reliable and secure than using a custom regex.

Steps to fix:
1. Install the `sanitize-html` library if it is not already installed.
2. Replace the `processedContent.replace(/<[^>]*>/g, '')` line with a call to `sanitize-html` to sanitize the content properly.
3. Ensure that the library is imported at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
