### PR TITLE
Potential fix for code scanning alert no. 16: Information exposure through a stack trace

### DIFF
--- a/src/app/api/trpc/[trpc]/route.ts
+++ b/src/app/api/trpc/[trpc]/route.ts
@@ -80,9 +80,7 @@ export async function POST(req: NextRequest) {
       JSON.stringify({
         message: 'Internal server error',
         // Only expose error details in development
-        ...(process.env.NODE_ENV === 'development' && {
-          error: errorMessage,
-        }),
+        // No detailed error information is exposed to the client
       }),
       {
         status: 500,


### PR DESCRIPTION
Potential fix for [https://github.com/hudsor01/tattoo-website/security/code-scanning/16](https://github.com/hudsor01/tattoo-website/security/code-scanning/16)

To address the issue, we will modify the error-handling logic to ensure that no stack trace or detailed error information is ever sent to the client, regardless of the environment. Instead, we will log the error details on the server using the `logger` utility. The client will always receive a generic error message, such as "Internal server error." This approach ensures that sensitive information is never exposed to end users.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
